### PR TITLE
Per thread timing

### DIFF
--- a/matmul/matmul.cpp
+++ b/matmul/matmul.cpp
@@ -112,7 +112,7 @@ bool GetUserInput(int argc, char *argv[])
 			case 'l': lockType = atoi(optarg);		  break;
 			case 'n': n = atoi(optarg);						  break;
 			case 'h': usage(argv[0], "");					  break;
-			case 't': timerTime = atoi(optarg);			break;
+			case 't': timerType = atoi(optarg);			break;
 			case 'T': enableTimer = false;					break;
 			default:  usage(argv[0], "Unrecognized option\n");
 		}
@@ -198,8 +198,8 @@ void timerOutput()
 		time_t s;
 		long ms;
 
-		s = times[i].tv_sec;
-		ms = round(times[i].tv_nsec / 1.0e3);
+		s = times[i]->tv_sec;
+		ms = round(times[i]->tv_nsec / 1.0e3);
 
 		printf("Elapsed: %d.%06ld seconds in #%ld.\n", s, ms, i);
 	}
@@ -302,8 +302,8 @@ void PrintMatrix(float **x)
 void* row_col_sum(void* idp) {
 	timespec start, end, elapsed;
 
-	int timesIndex = id;
 	int id = *(int*)idp;
+	int timesIndex = id;
 	int k = id % n;
 	id = id/n;
 	int j = id % n;
@@ -373,7 +373,7 @@ void* row_col_sum(void* idp) {
 		}
 
 		timespec_diff(&start, &end, &elapsed);
-		times[timesIndex] = elapsed;
+		times[timesIndex] = &elapsed;
 	}
 
 	if (!sequential)

--- a/matmul/matmul.cpp
+++ b/matmul/matmul.cpp
@@ -102,7 +102,7 @@ bool GetUserInput(int argc, char *argv[])
 {
 	int opt;
 	// read program args
-	while ((opt = getopt(argc, argv, "hDSn:l:p:m:")) != -1) {
+	while ((opt = getopt(argc, argv, "hDSn:l:p:m:t:T")) != -1) {
 		switch (opt) {
 			case 'p': priority = atoi(optarg);
 								prioritySet = true;						break;

--- a/matmul/matmul.cpp
+++ b/matmul/matmul.cpp
@@ -60,6 +60,11 @@ pthread_attr_t attr;
 // debugging arg
 bool debug = false;
 
+// Timing stuff
+timespec **times;
+int timerType = 0;
+bool enableTimer = true;
+
 //-----------------------------------------------------------------------
 //   Get user input for matrix dimension or printing option
 //-----------------------------------------------------------------------
@@ -84,6 +89,12 @@ usage(char *prog_name, string msg)
 	fpe("           1 : Mutex\n");
 	fpe("           2 : Semaphore\n");
 	fpe("           3 : Spinlock\n");
+	fpe("-t<tmr>  Set the timer type\n");
+	fpe("           0 : CLOCK_REALTIME \n");
+	fpe("           1 : CLOCK_MONOTONIC \n");
+	fpe("           2 : CLOCK_MONOTONIC_RAW \n");
+	fpe("           3 : CLOCK_THREAD_CPUTIME_ID \n");
+	fpe("-T       Disable timing output\n");
 	exit(EXIT_FAILURE);
 }
 
@@ -101,6 +112,8 @@ bool GetUserInput(int argc, char *argv[])
 			case 'l': lockType = atoi(optarg);		  break;
 			case 'n': n = atoi(optarg);						  break;
 			case 'h': usage(argv[0], "");					  break;
+			case 't': timerTime = atoi(optarg);			break;
+			case 'T': enableTimer = false;					break;
 			default:  usage(argv[0], "Unrecognized option\n");
 		}
 	}
@@ -179,6 +192,19 @@ void timespec_diff(struct timespec *start, struct timespec *stop,
 	return;
 }
 
+void timerOutput()
+{
+	for (int i = 0; i < n*n*n; i++) {
+		time_t s;
+		long ms;
+
+		s = times[i].tv_sec;
+		ms = round(times[i].tv_nsec / 1.0e3);
+
+		printf("Elapsed: %d.%06ld seconds in #%ld.\n", s, ms, i);
+	}
+}
+
 //-----------------------------------------------------------------------
 //Initialize the value of matrix x[n x n]
 //-----------------------------------------------------------------------
@@ -234,6 +260,14 @@ void InitializeMatrix(float** &x, float value)
 		threads[i] = new helper();
 		threads[i]->idx = i;
 	}
+
+	if (enableTimer) {
+		// initialize timing structs
+		times = new timespec *[n * n * n];
+		for (int i = 0; i < n * n * n; i++) {
+			times[i] = new timespec();
+		}
+	}
 }
 
 //------------------------------------------------------------------
@@ -266,12 +300,33 @@ void PrintMatrix(float **x)
 
 // individual result matrix cell thread callback
 void* row_col_sum(void* idp) {
+	timespec start, end, elapsed;
+
+	int timesIndex = id;
 	int id = *(int*)idp;
-	int k = id % n; 
+	int k = id % n;
 	id = id/n;
 	int j = id % n;
 	id = id/n;
 	int i = id % n;
+
+	if (enableTimer) {
+		switch (timerType) {
+			case 0:
+				clock_gettime(CLOCK_REALTIME, &start);
+				break;
+			case 1:
+				clock_gettime(CLOCK_MONOTONIC, &start);
+				break;
+			case 2:
+				clock_gettime(CLOCK_MONOTONIC_RAW, &start);
+				break;
+			case 3:
+				clock_gettime(CLOCK_THREAD_CPUTIME_ID, &start);
+				break;
+		}
+	}
+
 	switch (lockType) {
 		// mutex
 		case 1:
@@ -300,6 +355,27 @@ void* row_col_sum(void* idp) {
 			c[i][j] += a[i][k]*b[k][j];
 			break;
 	}
+
+	if (enableTimer) {
+		switch (timerType) {
+			case 0:
+				clock_gettime(CLOCK_REALTIME, &end);
+				break;
+			case 1:
+				clock_gettime(CLOCK_MONOTONIC, &end);
+				break;
+			case 2:
+				clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+				break;
+			case 3:
+				clock_gettime(CLOCK_THREAD_CPUTIME_ID, &end);
+				break;
+		}
+
+		timespec_diff(&start, &end, &elapsed);
+		times[timesIndex] = elapsed;
+	}
+
 	if (!sequential)
 		pthread_exit(NULL);
 }
@@ -428,6 +504,9 @@ int main(int argc, char *argv[])
 		cout << "ok\t" << endl;
 	else
 		cout << "wrong\t" << endl;
+
+	if (enableTimer)
+		timerOutput();
 
 	DeleteMatrix(a);	
 	DeleteMatrix(b);	

--- a/matmul/matmul.cpp
+++ b/matmul/matmul.cpp
@@ -156,6 +156,29 @@ bool GetUserInput(int argc, char *argv[])
 	return true;
 }
 
+/**
+ * Difference between two timespec structs.
+ *
+ * Source: https://gist.github.com/diabloneo/9619917
+ *
+ * @param timespec* start
+ * @param timespec* stop
+ * @param timespec* result
+ */
+void timespec_diff(struct timespec *start, struct timespec *stop,
+				   struct timespec *result)
+{
+	if ((stop->tv_nsec - start->tv_nsec) < 0) {
+		result->tv_sec = stop->tv_sec - start->tv_sec - 1;
+		result->tv_nsec = stop->tv_nsec - start->tv_nsec + 1000000000;
+	} else {
+		result->tv_sec = stop->tv_sec - start->tv_sec;
+		result->tv_nsec = stop->tv_nsec - start->tv_nsec;
+	}
+
+	return;
+}
+
 //-----------------------------------------------------------------------
 //Initialize the value of matrix x[n x n]
 //-----------------------------------------------------------------------

--- a/matmul/matmul.cpp
+++ b/matmul/matmul.cpp
@@ -199,9 +199,17 @@ void timerOutput()
 		long ms;
 
 		s = times[i]->tv_sec;
-		ms = round(times[i]->tv_nsec / 1.0e3);
+		// milliseconds
+		//ms = round(times[i]->tv_nsec / 1.0e6);
+		//printf("Elapsed: %d.%03ld seconds in #%ld.\n", s, ms, i);
 
-		printf("Elapsed: %d.%06ld seconds in #%ld.\n", s, ms, i);
+		// microseconds
+		//ms = round(times[i]->tv_nsec / 1.0e3);
+		//printf("Elapsed: %d.%06ld seconds in #%ld.\n", s, ms, i);
+
+		// nanoseconds
+		ms = times[i]->tv_nsec;
+		printf("Elapsed: %d.%09ld seconds in #%ld.\n", s, ms, i);
 	}
 }
 
@@ -300,7 +308,7 @@ void PrintMatrix(float **x)
 
 // individual result matrix cell thread callback
 void* row_col_sum(void* idp) {
-	timespec start, end, elapsed;
+	timespec start, end;
 
 	int id = *(int*)idp;
 	int timesIndex = id;
@@ -372,8 +380,7 @@ void* row_col_sum(void* idp) {
 				break;
 		}
 
-		timespec_diff(&start, &end, &elapsed);
-		times[timesIndex] = &elapsed;
+		timespec_diff(&start, &end, times[timesIndex]);
 	}
 
 	if (!sequential)


### PR DESCRIPTION
I added per thread timing.
There's a number of options for the timer type we can use, I chose 4 of them to check out, and I'm not really sure what some of them even actually are, but you definitely get different numbers by switching which one you're using. You can use -t[0-3] to switch, the default is regular wall clock time.

I did a simple output for them, it waits until after everything is done to spit them all out.

The timer can also be disabled with -T.